### PR TITLE
Update anti-adblock.txt

### DIFF
--- a/anti-adblock.txt
+++ b/anti-adblock.txt
@@ -1,14 +1,14 @@
 [Adblock Plus 2.0]
 ! Title: Polish Anti Adblock Filters
 ! Oficjalne polskie filtry przeciwko alertom o Adblocku
-! Last modified: 24 December 2018
+! Last modified: 25 December 2018
 ! Expires: 2 days
-! Version: 2018122401
+! Version: 2018122501
 ! Support:
 !   Github >> https://github.com/olegwukr/polish-privacy-filters/issues
 ! License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 ! Copyright (C) 2018 
-! v.2018122401 aktualizacja: pon, 24 grudnia 2018, 10:35:00
+! v.2018122501 aktualizacja: wt, 25 grudnia 2018, 11:56:00
 !
 !
 !-----------------------Integration of supplement lists for uBlock & AdGuard-----------------------!
@@ -201,7 +201,7 @@ zycietoprzygoda.pl##[class^="tws_"]
 ||z4y.pl/js/badb.js
 !
 !3#---------------------------------Anti Adblock Rules whitelist filters----------------------------------!
-@@/adblockdetect/$script,domain=to.com.pl|dziennikbaltycki.pl|dziennikbaltycki.pl|dzienniklodzki.pl|dzienniklodzki.pl|dziennikzachodni.pl|dziennikzachodni.pl|expressilustrowany.pl|gazetakrakowska.pl|gazetakrakowska.pl|gazetawroclawska.pl|gazetawroclawska.pl|gloswielkopolski.pl|gloswielkopolski.pl|kurierlubelski.pl|kurierlubelski.pl|nto.pl|nto.pl|wspolczesna.pl|wspolczesna.pl|poranny.pl|poranny.pl|pomorska.pl|pomorska.pl|gp24.pl|gp24.pl|gazetalubuska.pl|gazetalubuska.pl|echodnia.eu|echodnia.eu|to.com.pl|to.com.pl|nowiny24.pl|nowiny24.pl|lubietubyc.pomorska.pl|polskatimes.pl|polskatimes.pl|gs24.pl|gs24.pl|gk24.pl|gk24.pl|expressbydgoski.pl|ekstramagazyn.pl|gazetakrakowska.pl
+@@/adblockdetect/*$script,domain=to.com.pl|dziennikbaltycki.pl|dzienniklodzki.pl|dziennikzachodni.pl|expressilustrowany.pl|gazetakrakowska.pl|gazetawroclawska.pl|gloswielkopolski.pl|kurierlubelski.pl|nto.pl|wspolczesna.pl|poranny.pl|pomorska.pl|gp24.pl|gazetalubuska.pl|echodnia.eu|nowiny24.pl|polskatimes.pl|gs24.pl|gk24.pl|expressbydgoski.pl|ekstramagazyn.pl
 @@/adframe.js$script,domain=kobieceporady.pl|allekoszyk.pl|samouczek.info|aranzujemy.pl|mondeoklubpolska.pl
 @@?ads=$image,domain=dziennikwschodni.pl
 @@/adsense.js$script,domain=biznesforum.pl|optyczne.pl|to.proste.info.pl|seciki.pl|kompnet.info|kolniak24.eu


### PR DESCRIPTION
Usunięte powtarzające się domeny, zbędne poddomeny i zbędny regex.

The following error, warning or optimalization was encountered while checking the rules:
`@@/adblockdetect/` : Unnecessary regular expression. Use `@@adblockdetect` instead, or use `@@/adblockdetect/*` if it isn't a regex

The following error, warning or optimalization was encountered while checking the rules:
`@@/adblockdetect/$script,domain=to.com.pl|dziennikbaltycki.pl|dziennikbaltycki.pl|dzienniklodzki.pl|dzienniklodzki.pl|dziennikzachodni.pl|dziennikzachodni.pl|expressilustrowany.pl|gazetakrakowska.pl|gazetakrakowska.pl|gazetawroclawska.pl|gazetawroclawska.pl|gloswielkopolski.pl|gloswielkopolski.pl|kurierlubelski.pl|kurierlubelski.pl|nto.pl|nto.pl|wspolczesna.pl|wspolczesna.pl|poranny.pl|poranny.pl|pomorska.pl|pomorska.pl|gp24.pl|gp24.pl|gazetalubuska.pl|gazetalubuska.pl|echodnia.eu|echodnia.eu|to.com.pl|to.com.pl|nowiny24.pl|nowiny24.pl|lubietubyc.pomorska.pl|polskatimes.pl|polskatimes.pl|gs24.pl|gs24.pl|gk24.pl|gk24.pl|expressbydgoski.pl|ekstramagazyn.pl|gazetakrakowska.pl`  : 

Some domains exists multiple time:

```
to.com.pl
to.com.pl
to.com.pl

gazetakrakowska.pl
gazetakrakowska.pl
gazetakrakowska.pl

dziennikbaltycki.pl
dziennikbaltycki.pl

dzienniklodzki.pl
dzienniklodzki.pl

dziennikzachodni.pl
dziennikzachodni.pl

echodnia.eu
echodnia.eu

gazetalubuska.pl
gazetalubuska.pl

gazetawroclawska.pl
gazetawroclawska.pl

gk24.pl
gk24.pl

gloswielkopolski.pl
gloswielkopolski.pl

gp24.pl
gp24.pl

gs24.pl
gs24.pl

kurierlubelski.pl
kurierlubelski.pl

nowiny24.pl
nowiny24.pl

nto.pl
nto.pl

polskatimes.pl
polskatimes.pl

pomorska.pl
pomorska.pl

poranny.pl
poranny.pl

wspolczesna.pl
wspolczesna.pl

```
Some subdomains are redundant:

`lubietubyc.pomorska.pl`